### PR TITLE
fix: iOS 11-13 arme64 launch WDA fix

### DIFF
--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -111,14 +111,24 @@ func runXCUIWithBundleIdsXcode11Ctx(
 func startTestRunner11(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,
 	sessionIdentifier string, testBundlePath string, wdaargs []string, wdaenv []string,
 ) (uint64, error) {
-	args := []interface{}{}
+	args := []interface{}{
+		"-NSTreatUnknownArgumentsAsOpen", "NO", "-ApplePersistenceIgnoreState", "YES",
+	}
 	for _, arg := range wdaargs {
 		args = append(args, arg)
 	}
 	env := map[string]interface{}{
-		"XCTestBundlePath":            testBundlePath,
-		"XCTestConfigurationFilePath": xctestConfigPath,
-		"XCTestSessionIdentifier":     sessionIdentifier,
+		"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0",
+		"CA_DEBUG_TRANSACTIONS":              "0",
+		"DYLD_INSERT_LIBRARIES":              "/Developer/usr/lib/libMainThreadChecker.dylib",
+
+		"MTC_CRASH_ON_REPORT":             "1",
+		"NSUnbufferedIO":                  "YES",
+		"OS_ACTIVITY_DT_MODE":             "YES",
+		"SQLITE_ENABLE_THREAD_ASSERTIONS": "1",
+		"XCTestBundlePath":                testBundlePath,
+		"XCTestConfigurationFilePath":     xctestConfigPath,
+		"XCTestSessionIdentifier":         sessionIdentifier,
 	}
 
 	for _, entrystring := range wdaenv {


### PR DESCRIPTION
- Adding additional parameters to startTestRunner11 to fix wda launches on selected iOS 11-13 models. not sure if its cpu specific but works on a failing arme64 device